### PR TITLE
Login component rendered after login on homepage #401 - avoid setting `intendedRoute` to 'login'

### DIFF
--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -16,7 +16,11 @@ export const mutations = {
         localStorage.setItem('isAuth', false);
         localStorage.removeItem('authorization');
     },
-    setIntendedRoute: (state, value) => (state.intendedRoute = value),
+    setIntendedRoute(state, value) {
+        if (value !== 'login') {
+            state.intendedRoute = value;
+        }
+    },
     setIntendedPath: (state, value) => (state.intendedPath = value),
 };
 


### PR DESCRIPTION
- fix for solution 2. described in #401 - avoid setting `intendedRoute` to 'login'. @aconeanu mentioned :"We never want the intended route to be login.". Issue occurred when a link was clicked while the app session was expired, and intendedRoute was overwriting initial intended route with additional API calls (like loading some filter options) which were redirected to login. This made the next page after login load a login form as homepage.

@Reviewer : 
1. I've tested similar behavior for `intendedPath` and did not find the same issue. If after session is expired the URL is force to a page where filters were loaded incorrectly before table, the  intendedPath is not set to `"/login"`. Therefore, **I did not felt that `setIntendedPath` needs changes.**
2. Regarding the explicit function codding - I've seed that you do not normally use hard to read code like:
```js
setIntendedRoute: (state, value) => (value !== 'login' && (state.intendedRoute = value))
``` 
neither one-line-ifs, so I keep the code plain and simple, similar to other enso-ui implementations.

Feel free to choose whatever form you like 👍🏼 